### PR TITLE
Corrige GitHub Actions para incluir cobertura de testes no node.js.yml

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,3 +29,8 @@ jobs:
     - run: npm install
     - run: npm run lint
     - run: npm run test
+    - name: Upload do relatório de cobertura
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-report
+        path: coverage/


### PR DESCRIPTION
Agora o relatório de cobertura será salvo como um artifact (coverage-report), permitindo baixar do GitHub Actions.